### PR TITLE
define nix, docker and docker dev env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,11 +88,6 @@
             tag = revision;
             contents = [ spex ];
           };
-          dockerDevImage = pkgs.dockerTools.buildLayeredImage {
-            name = "spex-dev";
-            tag = revision;
-            contents = [ spex ] ++ (devPackages pkgs);
-          };
         });
 
       # nix develop <flake-ref>#<name>
@@ -101,16 +96,6 @@
       # $ nix develop <flake-ref>#yellow
       devShells = forAllSystems ({ pkgs }:
         let
-          upstream = with pkgs;
-            [
-              (python311.withPackages
-                (pypkgs: with pypkgs; [ lxml jsonschema ]))
-            ];
-          custom = with self.packages.${pkgs.system}; [
-            gcgen
-            lxml-stubs
-            loguru
-          ];
         in {
           default = pkgs.mkShell {
             name = "default";


### PR DESCRIPTION
```
jwd@jwdssdr ~/r/spex (dockdock)> docker image ls
REPOSITORY   TAG                    IMAGE ID       CREATED        SIZE
debian       latest                 3676c78a12ad   35 hours ago   116MB
python       latest                 c0e63845ae98   3 weeks ago    1.01GB
spex-dev     20230704152754-dirty   79318d060ee8   53 years ago   325MB
spex         20230704152754-dirty   7446401dac0f   53 years ago   186MB
```


**EDIT**: removed separate docker development image after discussion.