### PR TITLE
ci: switch runners to hosted ubuntu-22.04

### DIFF
--- a/.github/workflows/build-docker-env.yml
+++ b/.github/workflows/build-docker-env.yml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   build-and-deploy-docker:
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   build-using-nix:
     name: Build using nix environment
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
 
     steps:
       - name: git checkout
@@ -35,7 +35,7 @@ jobs:
 
   build-using-docker:
     name: Build using docker environment
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     container: ghcr.io/openmpdk/spex/spex-env:latest
 
     steps:


### PR DESCRIPTION
The ci jobs do not require self-hosted runners, these where only needed to prevent using ci-credits when the project was private. This switches to run on github provided Ubuntu 22.04 environment.