### PR TITLE
fix: Replace raising of base `Exception` with specific

### DIFF
--- a/src/spex/htmlspec/docx/numbering.py
+++ b/src/spex/htmlspec/docx/numbering.py
@@ -65,11 +65,26 @@ T = TypeVar("T")
 
 
 def coerce(v: Any, t: Type[T], f: Callable[[Any], T]) -> T:
+    """_summary_
+
+    Args:
+        v (Any): value
+        t (Type[T]): type
+        f (Callable[[Any], T]): function
+
+    Raises:
+        ValueError: If `v` is None `coerce` will raise a ValueError
+        TypeError: If result of applying f to v is not of type `t`, `coerce`
+        will raise a TypeError
+
+    Returns:
+        T: _description_
+    """
     if v is None:
-        raise Exception("expected a value")
+        raise ValueError("Expected `v` to be not None")
     cv = f(v)
     if not isinstance(cv, t):
-        raise Exception(f"expected value of type {t}, got {type(cv)}")
+        raise TypeError(f"Expected value of type {t}, got {type(cv)}")
     return cv
 
 

--- a/src/spex/jsonspec/exceptions.py
+++ b/src/spex/jsonspec/exceptions.py
@@ -49,3 +49,11 @@ class XPathInvalidQueryException(XPathException):
         self.message: str = message
         self.query: Optional[str] = query
         self.details: Optional[Any] = details
+
+
+class LabelExtractionError(Exception):
+    """Custom exception raised for errors in label extraction."""
+
+    def __init__(self, message="Error occurred while extracting label"):
+        self.message = message
+        super().__init__(self.message)

--- a/src/spex/jsonspec/extractors/valuetable.py
+++ b/src/spex/jsonspec/extractors/valuetable.py
@@ -6,6 +6,7 @@ from dataclasses import replace as dataclass_replace
 from typing import TYPE_CHECKING, Any, Generator, Iterator, List, Optional, Union, cast
 
 from spex.jsonspec.defs import ELLIPSIS, RESERVED, ValueField
+from spex.jsonspec.exceptions import LabelExtractionError
 from spex.jsonspec.extractors.figure import FigureExtractor, RowErrPolicy
 from spex.jsonspec.extractors.helpers import (
     ValueTableMapping,
@@ -268,7 +269,7 @@ class ValueTableExtractor(FigureExtractor):
             text: Optional[str] = extract_content(data)
             if text is None:
                 self.add_issue(LintErr.LBL_EXTRACT_ERR, row_key=row_key)
-                raise Exception("Could not extract label")
+                raise LabelExtractionError("Could not extract label")
             if text.upper() == RESERVED:
                 return RESERVED
             match = VALUE_LABEL_REGEX.regex.match(text)


### PR DESCRIPTION
To align spex with normal exception usage in python, another custom is exception is implemented, called `LabelExtractionError`.

All calls to raise the base exception, `Exception` is replaced by other standardized python or exception or the new one.